### PR TITLE
[ZB-3641] no errors on undefined

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ yarn-error.log
 
 # .vscode config
 .vscode/
+
+# OS X file
+.DS_store

--- a/src/__tests__/tform-test.ts
+++ b/src/__tests__/tform-test.ts
@@ -112,13 +112,6 @@ describe('tform', () => {
         recordNo: 2,
         recordRaw: {},
       },
-      {
-        error: Error("Property 'missing' of result is undefined"),
-        field: 'missing',
-        recordId: undefined,
-        recordNo: 2,
-        recordRaw: {},
-      },
     ]);
   });
 
@@ -134,21 +127,7 @@ describe('tform', () => {
     expect(tform.transform(record2)).toEqual({});
     expect(tform.getErrors()).toEqual([
       {
-        error: Error("Property 'missing' of result is undefined"),
-        field: 'missing',
-        recordId: '1',
-        recordNo: 1,
-        recordRaw: { pk: 1 },
-      },
-      {
         error: TypeError("Missing ID key 'pk'"),
-        recordNo: 2,
-        recordRaw: {},
-      },
-      {
-        error: Error("Property 'missing' of result is undefined"),
-        field: 'missing',
-        recordId: undefined,
         recordNo: 2,
         recordRaw: {},
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,10 +49,6 @@ export class Tform<InRecord, OutRecord> {
         // If rule is a function, call the rule function; otherwise traverse object.
         results[key] = _.isFunction(rule) ? rule(oc(record)) : this._processRules(rule, record);
 
-        if (results[key] === undefined) {
-          throw Error(`Property '${key}' of result is undefined`);
-        }
-
         if (_.isString(results[key])) {
           results[key] = results[key].trim();
         }


### PR DESCRIPTION
Summary:
Do not create errors when a field is undefined -- many fields can be undefined for legitimate reasons. These errors were very noisy.

Test Plan:
yarn build
yarn test