### PR TITLE
[ZB-6720] Modify Tform to trace output keys to input keys

### DIFF
--- a/src/__tests__/tform-test.ts
+++ b/src/__tests__/tform-test.ts
@@ -77,9 +77,22 @@ describe('tform', () => {
       },
     };
 
+    const expectedKeyToInputKeyMap = new Map<string | number | symbol, Set<string | number | symbol>>();
+    expectedKeyToInputKeyMap.set('job', new Set<string | number | symbol>());
+    const expectedJobInput = expectedKeyToInputKeyMap.get('job');
+    if (expectedJobInput) {
+      expectedJobInput.add('job');
+    }
+    expectedKeyToInputKeyMap.set('first', new Set<string | number | symbol>());
+    const expectedFirstInput = expectedKeyToInputKeyMap.get('first');
+    if (expectedFirstInput) {
+      expectedFirstInput.add('name');
+    }
     const tform = new Tform(rules);
     const output = tform.transform(record);
     expect(output).toEqual(expected);
+    expect(tform.getKeyToInputKeyMap().get('job')).toEqual(expectedJobInput);
+    expect(tform.getKeyToInputKeyMap().get('first')).toEqual(expectedFirstInput);
   });
 
   test('basic error handling', () => {

--- a/src/__tests__/tform-test.ts
+++ b/src/__tests__/tform-test.ts
@@ -77,22 +77,22 @@ describe('tform', () => {
       },
     };
 
-    const expectedKeyToInputKeyMap = new Map<string | number | symbol, Set<string | number | symbol>>();
-    expectedKeyToInputKeyMap.set('job', new Set<string | number | symbol>());
-    const expectedJobInput = expectedKeyToInputKeyMap.get('job');
+    const expectedKeyMap = new Map<string | number | symbol, Set<string | number | symbol>>();
+    expectedKeyMap.set('job', new Set<string | number | symbol>());
+    const expectedJobInput = expectedKeyMap.get('job');
     if (expectedJobInput) {
       expectedJobInput.add('job');
     }
-    expectedKeyToInputKeyMap.set('first', new Set<string | number | symbol>());
-    const expectedFirstInput = expectedKeyToInputKeyMap.get('first');
+    expectedKeyMap.set('first', new Set<string | number | symbol>());
+    const expectedFirstInput = expectedKeyMap.get('first');
     if (expectedFirstInput) {
       expectedFirstInput.add('name');
     }
     const tform = new Tform(rules);
     const output = tform.transform(record);
     expect(output).toEqual(expected);
-    expect(tform.getKeyToInputKeyMap().get('job')).toEqual(expectedJobInput);
-    expect(tform.getKeyToInputKeyMap().get('first')).toEqual(expectedFirstInput);
+    expect(tform.getKeyMapAfterTransform().get('job')).toEqual(expectedJobInput);
+    expect(tform.getKeyMapAfterTransform().get('first')).toEqual(expectedFirstInput);
   });
 
   test('basic error handling', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,12 @@ export class Tform<InRecord, OutRecord> {
       const rule = rules[key];
 
       if (_.isFunction(rule)) {
-        this.keyToInputKeyMap.set(key, new Set<string | number | symbol>());
+        // Make sure not to overwrite an existing mapping due to recursive traversal of rules.
+        const origSetFromMapKey = this.keyToInputKeyMap.get(key);
+        if (!origSetFromMapKey) {
+          this.keyToInputKeyMap.set(key, new Set<string | number | symbol>());
+        }
+
         const setFromMapKey = this.keyToInputKeyMap.get(key);
         if (!setFromMapKey) {
           this._addError(Error('Failed to add key to keyToInputKeyMap'), record, key);


### PR DESCRIPTION
## Description
- Add `_tracePropAccess`, which wraps a given object with a Proxy function that traces which of its properties are accessed by other functions
- In `_processRules`, pass `record` wrapped in `_tracePropAccess` in addition to just `record`
- Add `getKeyMapAfterTransform`, which, after a call to `transform`, will contain a mapping of output keys to the input keys their corresponding rules accessed

**NOTE: `getKeyMapAfterTransform` will only contain the input keys actually accessed by the rules, so if there are conditional statements, it may not contain all of the possible input keys.**

**NOTE 2: if there are bottom-level keys with the same output key name, the mapping for that name will go to a set with all of their input keys. This mirrors the behavior of `_addErrors`, which lists all errors for one output key name under one label.**

**NOTE 3: `getKeyMapAfterTransform` will return an empty map if `transform` is not called first.**

## Test Plan
- Added tests to `tform-test`
- The full map object for the `basic transforming` test in `tform-test` is:
<img width="720" alt="Screen Shot 2019-08-12 at 4 37 27 PM" src="https://user-images.githubusercontent.com/51676038/62905481-913f6e80-bd1f-11e9-9298-aebd568e3a59.png">
(can update the test to check everything if we would prefer. would just be adding a lot of lines)

## Relevant Tasks
[ZB-6720]

## Post Merge Plan